### PR TITLE
GRIDIT-14 modify workerjs to use manifest

### DIFF
--- a/_worker.js
+++ b/_worker.js
@@ -1,3 +1,6 @@
+import manifestJSON from '__STATIC_CONTENT_MANIFEST';
+const manifest = JSON.parse(manifestJSON);
+
 export default {
   async fetch(request, env, ctx) {
     try {
@@ -13,15 +16,6 @@ export default {
       }
       
       console.log('__STATIC_CONTENT binding found, attempting to serve request');
-      // Parse the static content manifest mapping original filenames to hashed keys
-      let manifest = {};
-      if (env.__STATIC_CONTENT_MANIFEST) {
-        try {
-          manifest = JSON.parse(env.__STATIC_CONTENT_MANIFEST);
-        } catch (e) {
-          console.error('Failed to parse __STATIC_CONTENT_MANIFEST:', e);
-        }
-      }
       
       const url = new URL(request.url);
       let path = url.pathname;


### PR DESCRIPTION
The worker now loads the static content manifest at startup, avoiding per-request parsing by importing it once and creating a constant manifest map
The fetch handler relies on this pre-parsed manifest to resolve asset keys, streamlining lookup without checking environment variables each request
Hopefully
Don't like hoping in these scenarios but it's all I have left